### PR TITLE
Fix allowedHosts for codesandbox

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -10,7 +10,7 @@ module.exports = {
   },
   devServer: {
     hot: true,
-    allowedHosts: [".preview.csb.app"],
+    allowedHosts: [".csb.app"],
   },
   module: {
     rules: [{ test: /.less$/, use: [{ loader: "less-loader" }], type: "css" }],


### PR DESCRIPTION
Related:  issue https://github.com/web-infra-dev/rspack/issues/4076

Fix proof: https://codesandbox.io/p/github/zakuru/rspack-demo/main?workspaceId=35b4c10c-cd9e-4f67-9beb-49d379c8b7e8

![image](https://github.com/web-infra-dev/rspack-demo/assets/171174/65808126-8f9d-4c2b-bbd5-0f1ff16bea5c)
